### PR TITLE
Base64 encode captions

### DIFF
--- a/lib/frinkiac/screencap.rb
+++ b/lib/frinkiac/screencap.rb
@@ -1,6 +1,7 @@
 require 'faraday'
 require 'json'
 require 'word_wrap'
+require 'base64'
 
 SITE_URL = 'https://frinkiac.com'
 API_URL = "#{SITE_URL}/api/search"
@@ -24,7 +25,7 @@ module Frinkiac
       caption = self.caption if caption.nil?
       caption = caption.join("\n") if caption.is_a?(Array)
 
-      "#{SITE_URL}/meme/#{episode}/#{timestamp}.jpg?lines=#{URI.escape caption}"
+      "#{SITE_URL}/meme/#{episode}/#{timestamp}.jpg?b64lines=#{Base64.strict_encode64 caption}"
     end
 
     def caption

--- a/test/fixtures/caption.yml
+++ b/test/fixtures/caption.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://frinkiac.com/api/search?q=strap%20in%20and%20feel%20the%20g%27s
+    uri: https://frinkiac.com/api/search?q=strap%20in%20and%20feel%20the%20g's
     body:
       encoding: US-ASCII
       string: ''
@@ -21,7 +21,7 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Date:
-      - Mon, 22 Feb 2016 01:11:37 GMT
+      - Wed, 24 Feb 2016 12:47:30 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -29,8 +29,8 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - __cfduid=d7bcb9150fcbc33a9359dae41a6744f971456103497; expires=Tue, 21-Feb-17
-        01:11:37 GMT; path=/; domain=.frinkiac.com; HttpOnly
+      - __cfduid=d0fc04bc39e3427748d6939c231279c411456318050; expires=Thu, 23-Feb-17
+        12:47:30 GMT; path=/; domain=.frinkiac.com; HttpOnly
       Cache-Control:
       - public, max-age=1800
       Cf-Cache-Status:
@@ -38,18 +38,18 @@ http_interactions:
       Vary:
       - Accept-Encoding
       Expires:
-      - Mon, 22 Feb 2016 01:41:37 GMT
+      - Wed, 24 Feb 2016 13:17:30 GMT
       Strict-Transport-Security:
       - max-age=15552000
       X-Content-Type-Options:
       - nosniff
       Cf-Ray:
-      - 2786d1698a8f289a-SJC
+      - 279b478704243596-LHR
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: '[{"Id":1384170,"Episode":"S10E13","Timestamp":774439,"Filename":""},{"Id":1384167,"Episode":"S10E13","Timestamp":774222,"Filename":""},{"Id":1384175,"Episode":"S10E13","Timestamp":775891,"Filename":""},{"Id":1384174,"Episode":"S10E13","Timestamp":775690,"Filename":""},{"Id":1384166,"Episode":"S10E13","Timestamp":774022,"Filename":""},{"Id":1384171,"Episode":"S10E13","Timestamp":775474,"Filename":""},{"Id":1384181,"Episode":"S10E13","Timestamp":776525,"Filename":""},{"Id":1384168,"Episode":"S10E13","Timestamp":774639,"Filename":""},{"Id":1384177,"Episode":"S10E13","Timestamp":776308,"Filename":""},{"Id":1384169,"Episode":"S10E13","Timestamp":775273,"Filename":""},{"Id":1384173,"Episode":"S10E13","Timestamp":775056,"Filename":""},{"Id":1384176,"Episode":"S10E13","Timestamp":776108,"Filename":""},{"Id":1384172,"Episode":"S10E13","Timestamp":774856,"Filename":""},{"Id":243579,"Episode":"S03E01","Timestamp":726679,"Filename":""},{"Id":243578,"Episode":"S03E01","Timestamp":725828,"Filename":""},{"Id":243575,"Episode":"S03E01","Timestamp":725094,"Filename":""},{"Id":243577,"Episode":"S03E01","Timestamp":725294,"Filename":""},{"Id":243571,"Episode":"S03E01","Timestamp":725477,"Filename":""},{"Id":243582,"Episode":"S03E01","Timestamp":728397,"Filename":""},{"Id":243570,"Episode":"S03E01","Timestamp":724760,"Filename":""},{"Id":243576,"Episode":"S03E01","Timestamp":726879,"Filename":""},{"Id":243587,"Episode":"S03E01","Timestamp":728964,"Filename":""},{"Id":243591,"Episode":"S03E01","Timestamp":729148,"Filename":""},{"Id":243585,"Episode":"S03E01","Timestamp":728781,"Filename":""},{"Id":243574,"Episode":"S03E01","Timestamp":726495,"Filename":""},{"Id":243583,"Episode":"S03E01","Timestamp":727263,"Filename":""},{"Id":243580,"Episode":"S03E01","Timestamp":727062,"Filename":""},{"Id":243592,"Episode":"S03E01","Timestamp":728013,"Filename":""},{"Id":243573,"Episode":"S03E01","Timestamp":726161,"Filename":""},{"Id":243568,"Episode":"S03E01","Timestamp":724927,"Filename":""},{"Id":243567,"Episode":"S03E01","Timestamp":724426,"Filename":""},{"Id":243588,"Episode":"S03E01","Timestamp":727830,"Filename":""},{"Id":243581,"Episode":"S03E01","Timestamp":727446,"Filename":""},{"Id":243566,"Episode":"S03E01","Timestamp":724593,"Filename":""},{"Id":243572,"Episode":"S03E01","Timestamp":725661,"Filename":""},{"Id":243584,"Episode":"S03E01","Timestamp":728580,"Filename":""},{"Id":243586,"Episode":"S03E01","Timestamp":727630,"Filename":""},{"Id":372526,"Episode":"S03E22","Timestamp":362835,"Filename":""},{"Id":1018020,"Episode":"S08E04","Timestamp":490973,"Filename":""},{"Id":1101621,"Episode":"S08E17","Timestamp":1213945,"Filename":""},{"Id":566689,"Episode":"S05E07","Timestamp":510676,"Filename":""},{"Id":994247,"Episode":"S07E25","Timestamp":844944,"Filename":""},{"Id":861908,"Episode":"S07E06","Timestamp":1160275,"Filename":""},{"Id":861899,"Episode":"S07E06","Timestamp":1159607,"Filename":""},{"Id":1024181,"Episode":"S08E05","Timestamp":341840,"Filename":""},{"Id":1434152,"Episode":"S10E21","Timestamp":1009874,"Filename":""},{"Id":610269,"Episode":"S05E14","Timestamp":528911,"Filename":""},{"Id":569129,"Episode":"S05E07","Timestamp":1058223,"Filename":""}]'
     http_version: 
-  recorded_at: Mon, 22 Feb 2016 01:11:37 GMT
+  recorded_at: Wed, 24 Feb 2016 12:47:30 GMT
 - request:
     method: get
     uri: https://frinkiac.com/api/caption?e=S10E13&t=774439
@@ -71,7 +71,7 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Date:
-      - Mon, 22 Feb 2016 01:11:37 GMT
+      - Wed, 24 Feb 2016 12:47:30 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -79,19 +79,19 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - __cfduid=da014649b0056bc7a00ac65f4244e20ef1456103497; expires=Tue, 21-Feb-17
-        01:11:37 GMT; path=/; domain=.frinkiac.com; HttpOnly
+      - __cfduid=d597716603d5fc1dc99a9f481a3d089be1456318050; expires=Thu, 23-Feb-17
+        12:47:30 GMT; path=/; domain=.frinkiac.com; HttpOnly
       Strict-Transport-Security:
       - max-age=15552000
       X-Content-Type-Options:
       - nosniff
       Cf-Ray:
-      - 2786d16aa1c31e9b-SJC
+      - 279b4789217534ee-LHR
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: '{"Frame":{"Id":1384170,"Episode":"S10E13","Timestamp":774439,"Filename":""},"Subtitles":[{"Id":108420,"Episode":"S10E13","StartTimestamp":772033,"EndTimestamp":773867,"Content":"NOBODY
         SNUGGLES WITH MAX POWER."},{"Id":108421,"Episode":"S10E13","StartTimestamp":773867,"EndTimestamp":776700,"Content":"YOU
         STRAP YOURSELF IN AND FEEL THE Gs!"}],"Nearby":[{"Id":1384165,"Episode":"S10E13","Timestamp":773805,"Filename":""},{"Id":1384166,"Episode":"S10E13","Timestamp":774022,"Filename":""},{"Id":1384167,"Episode":"S10E13","Timestamp":774222,"Filename":""},{"Id":1384170,"Episode":"S10E13","Timestamp":774439,"Filename":""},{"Id":1384168,"Episode":"S10E13","Timestamp":774639,"Filename":""},{"Id":1384172,"Episode":"S10E13","Timestamp":774856,"Filename":""},{"Id":1384173,"Episode":"S10E13","Timestamp":775056,"Filename":""}]}'
     http_version: 
-  recorded_at: Mon, 22 Feb 2016 01:11:37 GMT
+  recorded_at: Wed, 24 Feb 2016 12:47:30 GMT
 recorded_with: VCR 3.0.1

--- a/test/fixtures/empty.yml
+++ b/test/fixtures/empty.yml
@@ -21,7 +21,7 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Date:
-      - Sun, 07 Feb 2016 21:25:08 GMT
+      - Wed, 24 Feb 2016 12:47:30 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -29,25 +29,25 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - __cfduid=ded4d875553168b49e44f2c5652cf787d1454880308; expires=Mon, 06-Feb-17
-        21:25:08 GMT; path=/; domain=.frinkiac.com; HttpOnly
+      - __cfduid=dd06168fac4a98acb0995a50a59200ca91456318050; expires=Thu, 23-Feb-17
+        12:47:30 GMT; path=/; domain=.frinkiac.com; HttpOnly
       Cache-Control:
       - public, max-age=1800
       Cf-Cache-Status:
-      - EXPIRED
+      - HIT
       Vary:
       - Accept-Encoding
       Expires:
-      - Sun, 07 Feb 2016 21:55:08 GMT
+      - Wed, 24 Feb 2016 13:17:30 GMT
       Strict-Transport-Security:
       - max-age=15552000
       X-Content-Type-Options:
       - nosniff
       Cf-Ray:
-      - 27122a661a0211bf-SJC
+      - 279b47852293348e-LHR
     body:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Sun, 07 Feb 2016 21:25:08 GMT
+  recorded_at: Wed, 24 Feb 2016 12:47:29 GMT
 recorded_with: VCR 3.0.1

--- a/test/fixtures/meme.yml
+++ b/test/fixtures/meme.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://frinkiac.com/api/search?q=strap%20in%20and%20feel%20the%20g%27s
+    uri: https://frinkiac.com/api/search?q=strap%20in%20and%20feel%20the%20g's
     body:
       encoding: US-ASCII
       string: ''
@@ -21,7 +21,7 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Date:
-      - Mon, 22 Feb 2016 01:11:36 GMT
+      - Wed, 24 Feb 2016 12:47:28 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -29,8 +29,8 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - __cfduid=d46b755f60e6468950255c41dcddeb3451456103496; expires=Tue, 21-Feb-17
-        01:11:36 GMT; path=/; domain=.frinkiac.com; HttpOnly
+      - __cfduid=da1e7a0aa9c0819396466db392bd7b8421456318048; expires=Thu, 23-Feb-17
+        12:47:28 GMT; path=/; domain=.frinkiac.com; HttpOnly
       Cache-Control:
       - public, max-age=1800
       Cf-Cache-Status:
@@ -38,18 +38,18 @@ http_interactions:
       Vary:
       - Accept-Encoding
       Expires:
-      - Mon, 22 Feb 2016 01:41:36 GMT
+      - Wed, 24 Feb 2016 13:17:28 GMT
       Strict-Transport-Security:
       - max-age=15552000
       X-Content-Type-Options:
       - nosniff
       Cf-Ray:
-      - 2786d166655b1ee9-SJC
+      - 279b477cc2df355a-LHR
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: '[{"Id":1384170,"Episode":"S10E13","Timestamp":774439,"Filename":""},{"Id":1384167,"Episode":"S10E13","Timestamp":774222,"Filename":""},{"Id":1384175,"Episode":"S10E13","Timestamp":775891,"Filename":""},{"Id":1384174,"Episode":"S10E13","Timestamp":775690,"Filename":""},{"Id":1384166,"Episode":"S10E13","Timestamp":774022,"Filename":""},{"Id":1384171,"Episode":"S10E13","Timestamp":775474,"Filename":""},{"Id":1384181,"Episode":"S10E13","Timestamp":776525,"Filename":""},{"Id":1384168,"Episode":"S10E13","Timestamp":774639,"Filename":""},{"Id":1384177,"Episode":"S10E13","Timestamp":776308,"Filename":""},{"Id":1384169,"Episode":"S10E13","Timestamp":775273,"Filename":""},{"Id":1384173,"Episode":"S10E13","Timestamp":775056,"Filename":""},{"Id":1384176,"Episode":"S10E13","Timestamp":776108,"Filename":""},{"Id":1384172,"Episode":"S10E13","Timestamp":774856,"Filename":""},{"Id":243579,"Episode":"S03E01","Timestamp":726679,"Filename":""},{"Id":243578,"Episode":"S03E01","Timestamp":725828,"Filename":""},{"Id":243575,"Episode":"S03E01","Timestamp":725094,"Filename":""},{"Id":243577,"Episode":"S03E01","Timestamp":725294,"Filename":""},{"Id":243571,"Episode":"S03E01","Timestamp":725477,"Filename":""},{"Id":243582,"Episode":"S03E01","Timestamp":728397,"Filename":""},{"Id":243570,"Episode":"S03E01","Timestamp":724760,"Filename":""},{"Id":243576,"Episode":"S03E01","Timestamp":726879,"Filename":""},{"Id":243587,"Episode":"S03E01","Timestamp":728964,"Filename":""},{"Id":243591,"Episode":"S03E01","Timestamp":729148,"Filename":""},{"Id":243585,"Episode":"S03E01","Timestamp":728781,"Filename":""},{"Id":243574,"Episode":"S03E01","Timestamp":726495,"Filename":""},{"Id":243583,"Episode":"S03E01","Timestamp":727263,"Filename":""},{"Id":243580,"Episode":"S03E01","Timestamp":727062,"Filename":""},{"Id":243592,"Episode":"S03E01","Timestamp":728013,"Filename":""},{"Id":243573,"Episode":"S03E01","Timestamp":726161,"Filename":""},{"Id":243568,"Episode":"S03E01","Timestamp":724927,"Filename":""},{"Id":243567,"Episode":"S03E01","Timestamp":724426,"Filename":""},{"Id":243588,"Episode":"S03E01","Timestamp":727830,"Filename":""},{"Id":243581,"Episode":"S03E01","Timestamp":727446,"Filename":""},{"Id":243566,"Episode":"S03E01","Timestamp":724593,"Filename":""},{"Id":243572,"Episode":"S03E01","Timestamp":725661,"Filename":""},{"Id":243584,"Episode":"S03E01","Timestamp":728580,"Filename":""},{"Id":243586,"Episode":"S03E01","Timestamp":727630,"Filename":""},{"Id":372526,"Episode":"S03E22","Timestamp":362835,"Filename":""},{"Id":1018020,"Episode":"S08E04","Timestamp":490973,"Filename":""},{"Id":1101621,"Episode":"S08E17","Timestamp":1213945,"Filename":""},{"Id":566689,"Episode":"S05E07","Timestamp":510676,"Filename":""},{"Id":994247,"Episode":"S07E25","Timestamp":844944,"Filename":""},{"Id":861908,"Episode":"S07E06","Timestamp":1160275,"Filename":""},{"Id":861899,"Episode":"S07E06","Timestamp":1159607,"Filename":""},{"Id":1024181,"Episode":"S08E05","Timestamp":341840,"Filename":""},{"Id":1434152,"Episode":"S10E21","Timestamp":1009874,"Filename":""},{"Id":610269,"Episode":"S05E14","Timestamp":528911,"Filename":""},{"Id":569129,"Episode":"S05E07","Timestamp":1058223,"Filename":""}]'
     http_version: 
-  recorded_at: Mon, 22 Feb 2016 01:11:36 GMT
+  recorded_at: Wed, 24 Feb 2016 12:47:28 GMT
 - request:
     method: get
     uri: https://frinkiac.com/api/caption?e=S10E13&t=774439
@@ -71,7 +71,7 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Date:
-      - Mon, 22 Feb 2016 01:11:37 GMT
+      - Wed, 24 Feb 2016 12:47:29 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -79,19 +79,19 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - __cfduid=d4151557399bf38fb379c6d6fb1e6940e1456103496; expires=Tue, 21-Feb-17
-        01:11:36 GMT; path=/; domain=.frinkiac.com; HttpOnly
+      - __cfduid=ddb46c47f979a5a5c38e710278277cfa31456318049; expires=Thu, 23-Feb-17
+        12:47:29 GMT; path=/; domain=.frinkiac.com; HttpOnly
       Strict-Transport-Security:
       - max-age=15552000
       X-Content-Type-Options:
       - nosniff
       Cf-Ray:
-      - 2786d167cc470296-SJC
+      - 279b4780317c1365-LHR
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: '{"Frame":{"Id":1384170,"Episode":"S10E13","Timestamp":774439,"Filename":""},"Subtitles":[{"Id":108420,"Episode":"S10E13","StartTimestamp":772033,"EndTimestamp":773867,"Content":"NOBODY
         SNUGGLES WITH MAX POWER."},{"Id":108421,"Episode":"S10E13","StartTimestamp":773867,"EndTimestamp":776700,"Content":"YOU
         STRAP YOURSELF IN AND FEEL THE Gs!"}],"Nearby":[{"Id":1384165,"Episode":"S10E13","Timestamp":773805,"Filename":""},{"Id":1384166,"Episode":"S10E13","Timestamp":774022,"Filename":""},{"Id":1384167,"Episode":"S10E13","Timestamp":774222,"Filename":""},{"Id":1384170,"Episode":"S10E13","Timestamp":774439,"Filename":""},{"Id":1384168,"Episode":"S10E13","Timestamp":774639,"Filename":""},{"Id":1384172,"Episode":"S10E13","Timestamp":774856,"Filename":""},{"Id":1384173,"Episode":"S10E13","Timestamp":775056,"Filename":""}]}'
     http_version: 
-  recorded_at: Mon, 22 Feb 2016 01:11:37 GMT
+  recorded_at: Wed, 24 Feb 2016 12:47:29 GMT
 recorded_with: VCR 3.0.1

--- a/test/fixtures/search.yml
+++ b/test/fixtures/search.yml
@@ -21,7 +21,7 @@ http_interactions:
       Server:
       - cloudflare-nginx
       Date:
-      - Sun, 07 Feb 2016 21:20:52 GMT
+      - Wed, 24 Feb 2016 12:47:29 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -29,25 +29,25 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - __cfduid=d1fc3c5fea21f67ce0ce22354c95741cd1454880052; expires=Mon, 06-Feb-17
-        21:20:52 GMT; path=/; domain=.frinkiac.com; HttpOnly
+      - __cfduid=db7ebbefa92f1b6a4dc4b4166def28dca1456318049; expires=Thu, 23-Feb-17
+        12:47:29 GMT; path=/; domain=.frinkiac.com; HttpOnly
       Cache-Control:
       - public, max-age=1800
       Cf-Cache-Status:
-      - EXPIRED
+      - HIT
       Vary:
       - Accept-Encoding
       Expires:
-      - Sun, 07 Feb 2016 21:50:52 GMT
+      - Wed, 24 Feb 2016 13:17:29 GMT
       Strict-Transport-Security:
       - max-age=15552000
       X-Content-Type-Options:
       - nosniff
       Cf-Ray:
-      - 2712242656d12834-SJC
+      - 279b47832636348e-LHR
     body:
-      encoding: ASCII-8BIT
-      string: '[{"Id":1201207,"Episode":"S09E09","Timestamp":40022,"Filename":""},{"Id":1201192,"Episode":"S09E09","Timestamp":37019,"Filename":""},{"Id":1201204,"Episode":"S09E09","Timestamp":39605,"Filename":""},{"Id":1201202,"Episode":"S09E09","Timestamp":38854,"Filename":""},{"Id":1201205,"Episode":"S09E09","Timestamp":39822,"Filename":""},{"Id":1201212,"Episode":"S09E09","Timestamp":40439,"Filename":""},{"Id":1201191,"Episode":"S09E09","Timestamp":36686,"Filename":""},{"Id":1201203,"Episode":"S09E09","Timestamp":39422,"Filename":""},{"Id":1201185,"Episode":"S09E09","Timestamp":36268,"Filename":""},{"Id":1201201,"Episode":"S09E09","Timestamp":39071,"Filename":""},{"Id":1201199,"Episode":"S09E09","Timestamp":38654,"Filename":""},{"Id":1201208,"Episode":"S09E09","Timestamp":40239,"Filename":""},{"Id":1201198,"Episode":"S09E09","Timestamp":38437,"Filename":""},{"Id":1201184,"Episode":"S09E09","Timestamp":36068,"Filename":""},{"Id":1201206,"Episode":"S09E09","Timestamp":39255,"Filename":""},{"Id":1201197,"Episode":"S09E09","Timestamp":38237,"Filename":""},{"Id":1201194,"Episode":"S09E09","Timestamp":37620,"Filename":""},{"Id":1201196,"Episode":"S09E09","Timestamp":38020,"Filename":""},{"Id":1201195,"Episode":"S09E09","Timestamp":37436,"Filename":""},{"Id":1201200,"Episode":"S09E09","Timestamp":37820,"Filename":""},{"Id":1201193,"Episode":"S09E09","Timestamp":37236,"Filename":""},{"Id":1201189,"Episode":"S09E09","Timestamp":36485,"Filename":""},{"Id":1201190,"Episode":"S09E09","Timestamp":36852,"Filename":""},{"Id":1018422,"Episode":"S08E04","Timestamp":565647,"Filename":""},{"Id":179409,"Episode":"S02E14","Timestamp":107468,"Filename":""},{"Id":1536427,"Episode":"S11E15","Timestamp":1106160,"Filename":""},{"Id":1018441,"Episode":"S08E04","Timestamp":568150,"Filename":""},{"Id":310036,"Episode":"S03E12","Timestamp":266999,"Filename":""},{"Id":337897,"Episode":"S03E16","Timestamp":968625,"Filename":""},{"Id":1317358,"Episode":"S10E02","Timestamp":890505,"Filename":""},{"Id":1078521,"Episode":"S08E14","Timestamp":141240,"Filename":""},{"Id":1391539,"Episode":"S10E14","Timestamp":1079160,"Filename":""},{"Id":1430275,"Episode":"S10E21","Timestamp":152768,"Filename":""},{"Id":199773,"Episode":"S02E17","Timestamp":223023,"Filename":""},{"Id":870107,"Episode":"S07E08","Timestamp":121904,"Filename":""},{"Id":1384816,"Episode":"S10E13","Timestamp":927092,"Filename":""},{"Id":1301727,"Episode":"S09E25","Timestamp":325774,"Filename":""},{"Id":1301722,"Episode":"S09E25","Timestamp":325107,"Filename":""},{"Id":870113,"Episode":"S07E08","Timestamp":122571,"Filename":""},{"Id":1018434,"Episode":"S08E04","Timestamp":567316,"Filename":""},{"Id":1539467,"Episode":"S11E16","Timestamp":483760,"Filename":""},{"Id":1018458,"Episode":"S08E04","Timestamp":571153,"Filename":""},{"Id":1504485,"Episode":"S11E10","Timestamp":632560,"Filename":""},{"Id":337904,"Episode":"S03E16","Timestamp":970777,"Filename":""},{"Id":642498,"Episode":"S05E19","Timestamp":760959,"Filename":""},{"Id":1504482,"Episode":"S11E10","Timestamp":630760,"Filename":""},{"Id":1351226,"Episode":"S10E08","Timestamp":273138,"Filename":""},{"Id":1417686,"Episode":"S10E19","Timestamp":100182,"Filename":""}]'
+      encoding: UTF-8
+      string: '[{"Id":1201200,"Episode":"S09E09","Timestamp":37820,"Filename":""},{"Id":1201208,"Episode":"S09E09","Timestamp":40239,"Filename":""},{"Id":1201197,"Episode":"S09E09","Timestamp":38237,"Filename":""},{"Id":1201203,"Episode":"S09E09","Timestamp":39422,"Filename":""},{"Id":1201189,"Episode":"S09E09","Timestamp":36485,"Filename":""},{"Id":1201202,"Episode":"S09E09","Timestamp":38854,"Filename":""},{"Id":1201204,"Episode":"S09E09","Timestamp":39605,"Filename":""},{"Id":1201194,"Episode":"S09E09","Timestamp":37620,"Filename":""},{"Id":1201198,"Episode":"S09E09","Timestamp":38437,"Filename":""},{"Id":1201201,"Episode":"S09E09","Timestamp":39071,"Filename":""},{"Id":1201191,"Episode":"S09E09","Timestamp":36686,"Filename":""},{"Id":1201212,"Episode":"S09E09","Timestamp":40439,"Filename":""},{"Id":1201192,"Episode":"S09E09","Timestamp":37019,"Filename":""},{"Id":1201193,"Episode":"S09E09","Timestamp":37236,"Filename":""},{"Id":1201190,"Episode":"S09E09","Timestamp":36852,"Filename":""},{"Id":1201196,"Episode":"S09E09","Timestamp":38020,"Filename":""},{"Id":1201184,"Episode":"S09E09","Timestamp":36068,"Filename":""},{"Id":1201206,"Episode":"S09E09","Timestamp":39255,"Filename":""},{"Id":1201199,"Episode":"S09E09","Timestamp":38654,"Filename":""},{"Id":1201195,"Episode":"S09E09","Timestamp":37436,"Filename":""},{"Id":1201207,"Episode":"S09E09","Timestamp":40022,"Filename":""},{"Id":1201185,"Episode":"S09E09","Timestamp":36268,"Filename":""},{"Id":1201205,"Episode":"S09E09","Timestamp":39822,"Filename":""},{"Id":1301718,"Episode":"S09E25","Timestamp":324606,"Filename":""},{"Id":231604,"Episode":"S02E21","Timestamp":1041846,"Filename":""},{"Id":1018422,"Episode":"S08E04","Timestamp":565647,"Filename":""},{"Id":179409,"Episode":"S02E14","Timestamp":107468,"Filename":""},{"Id":1536427,"Episode":"S11E15","Timestamp":1106160,"Filename":""},{"Id":1018441,"Episode":"S08E04","Timestamp":568150,"Filename":""},{"Id":310036,"Episode":"S03E12","Timestamp":266999,"Filename":""},{"Id":337897,"Episode":"S03E16","Timestamp":968625,"Filename":""},{"Id":1317358,"Episode":"S10E02","Timestamp":890505,"Filename":""},{"Id":1078521,"Episode":"S08E14","Timestamp":141240,"Filename":""},{"Id":1391539,"Episode":"S10E14","Timestamp":1079160,"Filename":""},{"Id":1430275,"Episode":"S10E21","Timestamp":152768,"Filename":""},{"Id":199773,"Episode":"S02E17","Timestamp":223023,"Filename":""},{"Id":870107,"Episode":"S07E08","Timestamp":121904,"Filename":""},{"Id":1384816,"Episode":"S10E13","Timestamp":927092,"Filename":""},{"Id":1301727,"Episode":"S09E25","Timestamp":325774,"Filename":""},{"Id":1301722,"Episode":"S09E25","Timestamp":325107,"Filename":""},{"Id":870113,"Episode":"S07E08","Timestamp":122571,"Filename":""},{"Id":1018434,"Episode":"S08E04","Timestamp":567316,"Filename":""},{"Id":1539467,"Episode":"S11E16","Timestamp":483760,"Filename":""},{"Id":1504485,"Episode":"S11E10","Timestamp":632560,"Filename":""},{"Id":337904,"Episode":"S03E16","Timestamp":970777,"Filename":""},{"Id":642498,"Episode":"S05E19","Timestamp":760959,"Filename":""},{"Id":1504482,"Episode":"S11E10","Timestamp":630760,"Filename":""},{"Id":1351226,"Episode":"S10E08","Timestamp":273138,"Filename":""}]'
     http_version: 
-  recorded_at: Sun, 07 Feb 2016 21:20:52 GMT
+  recorded_at: Wed, 24 Feb 2016 12:47:29 GMT
 recorded_with: VCR 3.0.1

--- a/test/frinkiac/screencap_test.rb
+++ b/test/frinkiac/screencap_test.rb
@@ -26,9 +26,9 @@ class FrinkiacScreencapTest < Minitest::Test
 
       screencap = results.first
 
-      assert_equal(1201207, screencap.id)
+      assert_equal(1201200, screencap.id)
       assert_equal('S09E09', screencap.episode)
-      assert_equal(40022, screencap.timestamp)
+      assert_equal(37820, screencap.timestamp)
     end
   end
 
@@ -36,7 +36,7 @@ class FrinkiacScreencapTest < Minitest::Test
     VCR.use_cassette('search') do
       screencap = Frinkiac::Screencap.search('lazy saturday').first
 
-      assert_equal('https://frinkiac.com/img/S09E09/40022.jpg', screencap.image_url)
+      assert_equal('https://frinkiac.com/img/S09E09/37820.jpg', screencap.image_url)
     end
   end
 
@@ -52,7 +52,7 @@ class FrinkiacScreencapTest < Minitest::Test
     VCR.use_cassette('meme') do
       screencap = Frinkiac::Screencap.search('strap in and feel the g\'s').first
 
-      assert_equal(screencap.meme_url, 'https://frinkiac.com/meme/S10E13/774439.jpg?lines=NOBODY%20SNUGGLES%20WITH%20MAX%0APOWER.%20YOU%20STRAP%0AYOURSELF%20IN%20AND%20FEEL%20THE%0AGs!')
+      assert_equal(screencap.meme_url, 'https://frinkiac.com/meme/S10E13/774439.jpg?b64lines=Tk9CT0RZIFNOVUdHTEVTIFdJVEggTUFYClBPV0VSLiBZT1UgU1RSQVAKWU9VUlNFTEYgSU4gQU5EIEZFRUwgVEhFCkdzIQ==')
     end
   end
 
@@ -60,7 +60,7 @@ class FrinkiacScreencapTest < Minitest::Test
     VCR.use_cassette('meme') do
       screencap = Frinkiac::Screencap.search('strap in and feel the g\'s').first
 
-      assert_equal(screencap.meme_url("NOBODY SNUGGLES WITH MAX POWER.\nYOU STRAP YOURSELF IN AND FEEL THE Gs!"), 'https://frinkiac.com/meme/S10E13/774439.jpg?lines=NOBODY%20SNUGGLES%20WITH%20MAX%20POWER.%0AYOU%20STRAP%20YOURSELF%20IN%20AND%20FEEL%20THE%20Gs!')
+      assert_equal(screencap.meme_url("NOBODY SNUGGLES WITH MAX POWER.\nYOU STRAP YOURSELF IN AND FEEL THE Gs!"), 'https://frinkiac.com/meme/S10E13/774439.jpg?b64lines=Tk9CT0RZIFNOVUdHTEVTIFdJVEggTUFYIFBPV0VSLgpZT1UgU1RSQVAgWU9VUlNFTEYgSU4gQU5EIEZFRUwgVEhFIEdzIQ==')
     end
   end
 
@@ -68,7 +68,7 @@ class FrinkiacScreencapTest < Minitest::Test
     VCR.use_cassette('meme') do
       screencap = Frinkiac::Screencap.search('strap in and feel the g\'s').first
 
-      assert_equal(screencap.meme_url(["NOBODY SNUGGLES WITH MAX POWER.","YOU STRAP YOURSELF IN AND FEEL THE Gs!"]), 'https://frinkiac.com/meme/S10E13/774439.jpg?lines=NOBODY%20SNUGGLES%20WITH%20MAX%20POWER.%0AYOU%20STRAP%20YOURSELF%20IN%20AND%20FEEL%20THE%20Gs!')
+      assert_equal(screencap.meme_url(["NOBODY SNUGGLES WITH MAX POWER.","YOU STRAP YOURSELF IN AND FEEL THE Gs!"]), 'https://frinkiac.com/meme/S10E13/774439.jpg?b64lines=Tk9CT0RZIFNOVUdHTEVTIFdJVEggTUFYIFBPV0VSLgpZT1UgU1RSQVAgWU9VUlNFTEYgSU4gQU5EIEZFRUwgVEhFIEdzIQ==')
     end
   end
 


### PR DESCRIPTION
I've noticed Frinkiac has changed slightly and now returns Base64 encoded captions, which makes for slightly nicer URLs. I've tweaked the gem to reflect this.
